### PR TITLE
Fix/cursor on temp table

### DIFF
--- a/examples/RunAllExamples.sql
+++ b/examples/RunAllExamples.sql
@@ -1,5 +1,4 @@
 PROMPT Run all examples
-Clear Screen
 set echo off
 set feedback off
 set linesize 1000

--- a/examples/RunUserExamples.sql
+++ b/examples/RunUserExamples.sql
@@ -1,12 +1,11 @@
 PROMPT Run user examples
-Clear Screen
---set echo off
---set feedback off
+set echo off
+set feedback off
 set linesize 1000
 
 prompt Common examples from web
 
-exec ut_documentation_reporter.set_color_enabled(true);
+exec ut_ansiconsole_helper.color_enabled(true);
 @@award_bonus/run_award_bonus_test.sql
 
 @@between_string/run_betwnstr_test.sql

--- a/source/core/ut_utils.pkb
+++ b/source/core/ut_utils.pkb
@@ -378,10 +378,8 @@ create or replace package body ut_utils is
   end;
 
   procedure cleanup_temp_tables is
-    pragma autonomous_transaction;
   begin
-    execute immediate 'truncate table ut_cursor_data';
-    commit;
+    execute immediate 'delete from ut_cursor_data';
   end;
 
 end ut_utils;


### PR DESCRIPTION
Removed clear screen from examples scripts.
Fixed color console setting.

Fixed error:
```
ORA-14462: cannot TRUNCATE temporary table in an autonomous transaction which is already in use by the parent transaction
ORA-06512: at "UT3.UT_UTILS", line 383
ORA-06512: at "UT3.UT_RUNNER", line 78
ORA-14462: cannot TRUNCATE temporary table in an autonomous transaction which is already in use by the parent transaction
ORA-06512: at "UT3.UT_RUNNER", line 110
ORA-06512: at "UT3.UT", line 292
ORA-06512: at "UT3.UT", line 320
ORA-06512: at line 1
```
Instead of truncate with autonomous_transaction we will now use delete (without autonomous_transaction )
